### PR TITLE
look for key id also in payload

### DIFF
--- a/scripts/src/errors.ts
+++ b/scripts/src/errors.ts
@@ -13,7 +13,8 @@ const CODES = {
 		MissingToken: 1,
 		InvalidToken: 2,
 		InvalidApiKey: 3,
-		TOSMissingOrOldToken: 4
+		JwtKidMissing: 4,
+		TosMissingOrOldToken: 5
 	},
 	NotFound: {
 		App: 1,
@@ -80,8 +81,12 @@ export function InvalidApiKey(apiKey: string) {
 	return UnauthorizedError(CODES.Unauthorized.InvalidApiKey, `invalid api key: ${ apiKey }`);
 }
 
-export function TOSMissingOrOldToken() {
-	return UnauthorizedError(CODES.Unauthorized.TOSMissingOrOldToken, "user did not approve TOS or using a pre activated token");
+export function JwtKidMissing() {
+	return UnauthorizedError(CODES.Unauthorized.JwtKidMissing, "kid is missing from the JWT");
+}
+
+export function TosMissingOrOldToken() {
+	return UnauthorizedError(CODES.Unauthorized.TosMissingOrOldToken, "user did not approve TOS or using a pre activated token");
 }
 
 function NotFoundError(index: number, message: string) {

--- a/scripts/src/public/routes/index.ts
+++ b/scripts/src/public/routes/index.ts
@@ -1,7 +1,7 @@
 import * as express from "express";
 
 import * as db from "../../models/users";
-import { TOSMissingOrOldToken } from "../../errors";
+import { TosMissingOrOldToken } from "../../errors";
 
 import { authenticate } from "../auth";
 
@@ -55,7 +55,7 @@ function Router(): ExtendedRouter {
 							const user = await db.User.findOneById(token.userId);
 							// XXX scopes should be per token and should not consider user data
 							if (scopes.includes(AuthScopes.TOS) && (!user || !user.activated || token.createdDate < user.activatedDate!)) {
-								throw TOSMissingOrOldToken();
+								throw TosMissingOrOldToken();
 							}
 							req.context = { user, token };
 


### PR DESCRIPTION
until now we looked for it only in the JWT headers, but for Elaz it's easier to add to the payload.
also, throw an error in case `kid` is missing.