### PR TITLE
fixed the nonce bug

### DIFF
--- a/docker-compose.deps.yaml
+++ b/docker-compose.deps.yaml
@@ -45,7 +45,7 @@ services:
       - 6379
 
   jwt-service:
-    image: kinecosystem/jwt-service:7e65140
+    image: kinecosystem/jwt-service:d91b094
     ports:
       - 3000
     environment:

--- a/package-lock.json
+++ b/package-lock.json
@@ -15685,9 +15685,9 @@
       }
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "sqlite3": "^4.0.2",
     "tslint": "^5.9.1",
     "tslint-eslint-rules": "^4.1.1",
-    "typescript": "^2.7.2"
+    "typescript": "^2.8"
   },
   "scripts": {
     "clean": "rimraf scripts/bin",

--- a/scripts/src/models/orders.ts
+++ b/scripts/src/models/orders.ts
@@ -17,7 +17,7 @@ import {
 } from "typeorm";
 
 import { ApiError } from "../errors";
-import { generateId, IdPrefix, Mutable } from "../utils";
+import { generateId, IdPrefix, Mutable, isNothing } from "../utils";
 
 import { User } from "./users";
 import { BlockchainData, OfferType, OrderValue } from "./offers";
@@ -323,13 +323,13 @@ export type ExternalOrderFactory = OrderFactory & {
 
 function extendedOrder(origin: OrderOrigin): (typeof Order) & OrderFactory {
 	return Object.assign({}, Order, {
-		"new"(data?: Mutable<DeepPartial<Order>>, ...context: Array<DeepPartial<OrderContext>>): Order {
+		"new"(data?: DeepPartial<Order>, ...context: Array<DeepPartial<OrderContext>>): Order {
 			data = Object.assign(
 				data,
 				{ origin });
 
-			if (typeof data.nonce !== "string") {
-				data.nonce = Order.DEFAULT_NONCE;
+			if (isNothing(data.nonce)) {
+				(data as Mutable<Order>).nonce = Order.DEFAULT_NONCE;
 			}
 
 			return createOrder(data, context!);

--- a/scripts/src/models/orders.ts
+++ b/scripts/src/models/orders.ts
@@ -17,7 +17,7 @@ import {
 } from "typeorm";
 
 import { ApiError } from "../errors";
-import { generateId, IdPrefix } from "../utils";
+import { generateId, IdPrefix, Mutable } from "../utils";
 
 import { User } from "./users";
 import { BlockchainData, OfferType, OrderValue } from "./offers";
@@ -323,11 +323,15 @@ export type ExternalOrderFactory = OrderFactory & {
 
 function extendedOrder(origin: OrderOrigin): (typeof Order) & OrderFactory {
 	return Object.assign({}, Order, {
-		"new"(data?: DeepPartial<Order>, ...context: Array<DeepPartial<OrderContext>>): Order {
+		"new"(data?: Mutable<DeepPartial<Order>>, ...context: Array<DeepPartial<OrderContext>>): Order {
 			data = Object.assign(
-				{ nonce: Order.DEFAULT_NONCE },
 				data,
 				{ origin });
+
+			if (typeof data.nonce !== "string") {
+				data.nonce = Order.DEFAULT_NONCE;
+			}
+
 			return createOrder(data, context!);
 		},
 

--- a/scripts/src/utils.ts
+++ b/scripts/src/utils.ts
@@ -14,6 +14,8 @@ export function isSimpleObject(obj: any): obj is SimpleObject {
 
 export type Nothing = null | undefined;
 
+export type Mutable<T> = { -readonly [P in keyof T ]: T[P] };
+
 export function isNothing(obj: any): obj is Nothing {
 	return obj === null || obj === undefined;
 }


### PR DESCRIPTION
there wasn't an option to not use the nonce, the previous code assumed that if no nonce was sent then the 'nonce' property wouldn't exist, but in reality it was there but with the value as undefined.
the tests did not catch it because the JWT service we used would add it's own nonce default value, that was fixed in the JWT service repo and the updated image is now used here.