### PR TITLE
rename create script and add option to only update offer's meta image 

### DIFF
--- a/.github
+++ b/.github
@@ -1,0 +1,1 @@
+* @kinecosystem/kin-ecosystem-sdk-backend

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test-system:
 
 db:
 	rm -f database.sqlite
-	npm run create-db -- --apps-dir data/apps --offers-dir data/offers --app-list ALL --create-db
+	npm run manage-db-data -- --apps-dir data/apps --offers-dir data/offers --app-list ALL --create-db
 
 con:
 	node -i --experimental-repl-await -e "require('./node-console')"

--- a/docker-compose.tests.yaml
+++ b/docker-compose.tests.yaml
@@ -21,7 +21,7 @@ services:
       - .:/opt/app
     links:
       - postgres
-    command: npm run create-db -- --apps-dir data/apps --offers-dir data/offers --app-list ALL --create-db
+    command: npm run manage-db-data -- --apps-dir data/apps --offers-dir data/offers --app-list ALL --create-db
     environment:
       APP_DB_TYPE: postgres
       APP_DB_USERNAME: user

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"build": "npm-run-all clean lint transpile",
 		"start": "node scripts/bin/public/index",
 		"start-internal": "node scripts/bin/internal/index",
-		"create-db": "node scripts/bin/create",
+		"create-db": "node scripts/bin/db_data",
 		"start-admin": "node scripts/bin/admin/index",
 		"restart": "npm-run-all build start",
 		"transpile-tests": "tsc -p tests",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"build": "npm-run-all clean lint transpile",
 		"start": "node scripts/bin/public/index",
 		"start-internal": "node scripts/bin/internal/index",
-		"create-db": "node scripts/bin/db_data",
+		"manage-db-data": "node scripts/bin/manage_db_data",
 		"start-admin": "node scripts/bin/admin/index",
 		"restart": "npm-run-all build start",
 		"transpile-tests": "tsc -p tests",

--- a/scripts/src/create_data/offers.ts
+++ b/scripts/src/create_data/offers.ts
@@ -141,7 +141,9 @@ export async function createEarn(
 	} else {
 		offer.amount = amount;
 		offer.meta = {
-			title, image, description,
+			title,
+			image,
+			description,
 			order_meta: {
 				title: orderTitle,
 				description: orderDescription,

--- a/scripts/src/create_data/offers.ts
+++ b/scripts/src/create_data/offers.ts
@@ -93,6 +93,7 @@ export async function createSpend(
 
 export type EarnOptions = {
 	doNotUpdateExiting?: boolean; // Should existing offers be updated
+	onlyUpdate?: boolean; // Don't create new offers, only update existing.
 	dryRun?: boolean;  // if true, only process data, don't change/insert into the DB
 	confirmUpdate?: boolean;  //
 	onlyUpdateMetaImage?: boolean;
@@ -105,7 +106,7 @@ export async function createEarn(
 	orderTitle: string, orderDescription: string, contentType: ContentType,
 	poll: Quiz | Poll | Tutorial,
 	appList: string[] = [],
-	options: EarnOptions = {}): Promise<Offer> {
+	options: EarnOptions = {}): Promise<Offer | null> {
 
 	const existingOffer = await Offer.findOne({ name: offerName });
 	let offer;
@@ -119,6 +120,10 @@ export async function createEarn(
 		console.log("Updating earn offer %s id %s", offer.name, offer.id, options.dryRun ? "(dry run)" : "");
 		content = await OfferContent.findOne({ offerId: offer.id });
 	} else {
+		if (options.onlyUpdate) {
+			console.log(`Skipping offer creation for offer: ${offerName}`);
+			return Promise.resolve(null);
+		}
 		const owner = await getOrCreateOwner(brand);
 		offer = Offer.new({ name: offerName, ownerId: owner.id, type: "earn" });
 		console.log("Creating earn offer %s id %s", offer.name, offer.id, options.dryRun ? "(dry run)" : "");

--- a/scripts/src/create_data/offers.ts
+++ b/scripts/src/create_data/offers.ts
@@ -121,7 +121,7 @@ export async function createEarn(
 		content = await OfferContent.findOne({ offerId: offer.id });
 	} else {
 		if (options.onlyUpdate) {
-			console.log(`Skipping offer creation for offer: ${offerName}`);
+			console.log(`Skipping offer creation for offer: ${ offerName }`);
 			return Promise.resolve(null);
 		}
 		const owner = await getOrCreateOwner(brand);

--- a/scripts/src/manage_db_data.ts
+++ b/scripts/src/manage_db_data.ts
@@ -247,25 +247,31 @@ function initArgsParser(): ScriptConfig {
 		action: "storeTrue"
 	});
 
-	// parser.addArgument(["-c", "--require-update-confirm"], {
-	// 	help: "Ask for confirmation before updating earn offers",
-	// 	action: "storeTrue"
-	// });
+/*
+//  implementation of a confirmation prompt function is below
+	parser.addArgument(["-c", "--require-update-confirm"], {
+		help: "Ask for confirmation before updating earn offers",
+		action: "storeTrue"
+	});
+*/
 	const parsed = parser.parseArgs();
 	parsed.app_list = parsed.app_list ? parsed.app_list.split(",") : [];
 	return parsed as ScriptConfig;
 }
 
-// function confirmPrompt(message: string) {
-// 	const readline = require("readline");
-// 	const prompt = readline.createInterface(process.stdin, process.stdout);
-// 	return new Promise(resolve => {
-// 		prompt.question(message + "\n", (answer: string) => {
-// 			prompt.close();
-// 			resolve(answer);
-// 		});
-// 	});
-// }
+/*
+//  When we decide to add this capability we should uncomment this
+function confirmPrompt(message: string) {
+	const readline = require("readline");
+	const prompt = readline.createInterface(process.stdin, process.stdout);
+	return new Promise(resolve => {
+		prompt.question(message + "\n", (answer: string) => {
+			prompt.close();
+			resolve(answer);
+		});
+	});
+}
+*/
 
 scriptConfig = initArgsParser();
 


### PR DESCRIPTION
1. Renamed the create script to db_data as it's purpose is not to create the DB anymore as much as it's to manage DB data (I thought of manage_db_data but opted for the shorter version, I'm willing to change it).
2. Added option to only update earn offer's meta image (thumbnails) - tested locally
3. Add only update existing and don't create new (earn) offers option
4. Added a `.github` file with code owners (this will mostly auto tag us for reviews)