### PR TITLE
add duration to rate limit prefix

### DIFF
--- a/scripts/src/public/services/orders.ts
+++ b/scripts/src/public/services/orders.ts
@@ -37,7 +37,7 @@ import {
 } from "../../analytics/events/earn_transaction_broadcast_to_blockchain_submitted";
 import { OrderTranslations } from "../routes/orders";
 
-import { throwOnAppEarnLimit, throwOnUserEarnLimit } from "../../utils/rate_limit";
+import { rateLimitAppEarn, rateLimitUserEarn, rateLimitWalletEarn } from "../../utils/rate_limit";
 
 export interface OrderList {
 	orders: Order[];
@@ -108,9 +108,10 @@ export async function changeOrder(orderId: string, userId: string, change: Parti
 async function createOrder(appOffer: AppOffer, user: User, orderTranslations = {} as OrderTranslations) {
 	const app = (await Application.findOneById(user.appId))!;
 	if (appOffer.offer.type === "earn") {
-		await throwOnAppEarnLimit(app.id, "total_earn", app.config.limits.minute_total_earn, moment.duration({ minutes: 1 }), appOffer.offer.amount);
-		await throwOnAppEarnLimit(app.id, "total_earn", app.config.limits.hourly_total_earn, moment.duration({ hours: 1 }), appOffer.offer.amount);
-		await throwOnUserEarnLimit(user.id, "user_earn", app.config.limits.daily_user_earn, moment.duration({ days: 1 }), appOffer.offer.amount);
+		await rateLimitAppEarn(app.id, app.config.limits.minute_total_earn, moment.duration({ minutes: 1 }), appOffer.offer.amount);
+		await rateLimitAppEarn(app.id, app.config.limits.hourly_total_earn, moment.duration({ hours: 1 }), appOffer.offer.amount);
+		await rateLimitUserEarn(user.id, app.config.limits.daily_user_earn, moment.duration({ days: 1 }), appOffer.offer.amount);
+		await rateLimitWalletEarn(user.walletAddress, app.config.limits.daily_user_earn, moment.duration({ days: 1 }), appOffer.offer.amount);
 	}
 
 	if (await appOffer.didExceedCap(user.id)) {
@@ -196,9 +197,10 @@ async function createP2PExternalOrder(sender: User, jwt: ExternalPayToUserOrderJ
 }
 
 async function createNormalEarnExternalOrder(recipient: User, jwt: ExternalEarnOrderJWT) {
-	const app = await Application.findOneById(recipient.appId);
+	const app = (await Application.findOneById(recipient.appId))!;
 
-	await throwOnUserEarnLimit(recipient.id, "user_earn", app!.config.limits.daily_user_earn, moment.duration({ days: 1 }), jwt.offer.amount);
+	await rateLimitUserEarn(recipient.id, app.config.limits.daily_user_earn, moment.duration({ days: 1 }), jwt.offer.amount);
+	await rateLimitWalletEarn(recipient.walletAddress, app.config.limits.daily_user_earn, moment.duration({ days: 1 }), jwt.offer.amount);
 
 	if (!app) {
 		throw NoSuchApp(recipient.appId);
@@ -328,7 +330,7 @@ export async function submitOrder(
 					// nothing
 					break;
 				default:
-					logger().warn(`unexpected content type ${offerContent.contentType}`);
+					logger().warn(`unexpected content type ${ offerContent.contentType }`);
 			}
 		}
 	}

--- a/scripts/src/public/services/users.ts
+++ b/scripts/src/public/services/users.ts
@@ -8,7 +8,7 @@ import { User, AuthToken as DbAuthToken } from "../../models/users";
 import * as payment from "./payment";
 import { readUTCDate } from "../../utils/utils";
 import { Brackets } from "typeorm";
-import { throwOnRateLimit } from "../../utils/rate_limit";
+import { rateLimitRegistration } from "../../utils/rate_limit";
 import * as moment from "moment";
 
 export type AuthToken = {
@@ -59,8 +59,8 @@ export async function getOrCreateUserCredentials(
 
 	let user = await User.findOne({ appId, appUserId });
 	if (!user) {
-		await throwOnRateLimit(app.id, "registration", app.config.limits.hourly_registration, moment.duration({ hours: 1 }));
-		await throwOnRateLimit(app.id, "registration", app.config.limits.minute_registration, moment.duration({ minutes: 1 }));
+		await rateLimitRegistration(app.id, app.config.limits.hourly_registration, moment.duration({ hours: 1 }));
+		await rateLimitRegistration(app.id, app.config.limits.minute_registration, moment.duration({ minutes: 1 }));
 		try {
 			logger().info("creating a new user", { appId, appUserId });
 			user = User.new({ appUserId, appId, walletAddress });

--- a/scripts/src/utils/rate_limit.ts
+++ b/scripts/src/utils/rate_limit.ts
@@ -2,40 +2,39 @@ import * as moment from "moment";
 
 import { getRedisClient, RedisAsyncClient } from "../redis";
 import { TooManyRegistrations, TooMuchEarnOrdered } from "../errors";
+import { Application } from "../models/applications";
 
-class RateLimit {
+export class RateLimit {
 	private readonly bucketPrefix: string;
-	private readonly rateLimitValue: number;
 	private readonly redis: RedisAsyncClient;
 	private readonly windowSize: number = 0;
 	private readonly bucketSize: number = 0;
 	private readonly currentTimestampSeconds: number = 0;
-	private readonly ttl: number = moment.duration({ days: 2 }).asSeconds(); // two days in seconds
+	private readonly ttl: number; // two days in seconds
 
 	/**
 	 * @param      {string}  bucketPrefix
-	 * @param      {number}  rateLimitValue
 	 * @param      {moment.Duration}  windowSizeMomentObject
 	 *
 	 * this.windowSize = windowSizeMomentObject in seconds
 	 * this.bucketSize = size of one bucket in seconds (at least 1 seconds)
 	 */
-	constructor(bucketPrefix: string, rateLimitValue: number, windowSizeMomentObject: moment.Duration) {
-		this.bucketPrefix = bucketPrefix;
-		this.rateLimitValue = rateLimitValue;
+	constructor(bucketPrefix: string, windowSizeMomentObject: moment.Duration) {
+		this.bucketPrefix = `rate_limit:${ bucketPrefix }:`;
+		this.currentTimestampSeconds = Math.trunc(Date.now() / 1000);
 		this.windowSize = windowSizeMomentObject.asSeconds();
 		this.bucketSize = Math.max(this.windowSize / 60, 1); // resolution
-		this.currentTimestampSeconds = Math.trunc(Date.now() / 1000);
+		this.ttl = this.windowSize * 2;
 		this.redis = getRedisClient();
 	}
 
 	public async checkRate(): Promise<number> {
-		this.createOrUpdateBucket(1);
+		await this.createOrUpdateBucket(1);
 		return await this.getSum();
 	}
 
 	public async checkAmount(amount: number): Promise<number> {
-		this.createOrUpdateBucket(amount);
+		await this.createOrUpdateBucket(amount);
 		return await this.getSum();
 	}
 
@@ -68,32 +67,38 @@ class RateLimit {
 	}
 }
 
-export async function throwOnRateLimit(appId: string, type: string, limit: number, duration: moment.Duration) {
-	const rateLimitPrefix: string = "rate_limit";
-	const bucketPrefix: string = `${ rateLimitPrefix }:${ appId }:${ type }:`;
-	const rateLimit: RateLimit = new RateLimit(bucketPrefix, limit, duration);
+export async function rateLimitRegistration(appId: string, limit: number, duration: moment.Duration) {
+	const type = `register:${ appId }:${ duration.asSeconds() }`;
+	const rateLimit: RateLimit = new RateLimit(type, duration);
 	const rateCount = await rateLimit.checkRate();
 	if (rateCount > limit) {
 		throw TooManyRegistrations(`app: ${ appId }, type: ${ type } exceeded the limit: ${ limit } with: ${ rateCount }`);
 	}
 }
 
-export async function throwOnAppEarnLimit(appId: string, type: string, limit: number, duration: moment.Duration, amount: number) {
-	const rateLimitPrefix: string = "amount_limit";
-	const bucketPrefix: string = `${ rateLimitPrefix }:${ appId }:${ type }:`;
-	const rateLimit: RateLimit = new RateLimit(bucketPrefix, limit, duration);
-	const appEarnSum = await rateLimit.checkAmount(amount);
-	if (appEarnSum > limit) {
-		throw TooMuchEarnOrdered(`app: ${ appId }, type: ${ type } exceeded the limit: ${ limit } with: ${ appEarnSum }`);
+export async function rateLimitAppEarn(appId: string, limit: number, duration: moment.Duration, amount: number) {
+	const type = `app_earn:${ appId }:${ duration.asSeconds() }`;
+	const rateLimit: RateLimit = new RateLimit(type, duration);
+	const rateCount = await rateLimit.checkAmount(amount);
+	if (rateCount > limit) {
+		throw TooMuchEarnOrdered(`app: ${ appId }, type: ${ type } exceeded the limit: ${ limit } with: ${ rateCount }`);
 	}
 }
 
-export async function throwOnUserEarnLimit(userId: string, type: string, limit: number, duration: moment.Duration, amount: number) {
-	const rateLimitPrefix: string = "amount_limit";
-	const bucketPrefix: string = `${ rateLimitPrefix }:${ userId }:${ type }:`;
-	const rateLimit: RateLimit = new RateLimit(bucketPrefix, limit, duration);
-	const userEarnSum = await rateLimit.checkAmount(amount);
-	if (userEarnSum > limit) {
-		throw TooMuchEarnOrdered(`user: ${ userId }, type: ${ type } exceeded the limit: ${ limit } with: ${ userEarnSum }`);
+export async function rateLimitUserEarn(userId: string, limit: number, duration: moment.Duration, amount: number) {
+	const type = `user_earn:${ userId }:${ duration.asSeconds() }`;
+	const rateLimit: RateLimit = new RateLimit(type, duration);
+	const rateCount = await rateLimit.checkAmount(amount);
+	if (rateCount > limit) {
+		throw TooMuchEarnOrdered(`user: ${ userId }, type: ${ type } exceeded the limit: ${ limit } with: ${ rateCount }`);
+	}
+}
+
+export async function rateLimitWalletEarn(wallet: string, limit: number, duration: moment.Duration, amount: number) {
+	const type = `wallet_earn:${ wallet }:${ duration.asSeconds() }`;
+	const rateLimit: RateLimit = new RateLimit(type, duration);
+	const rateCount = await rateLimit.checkAmount(amount);
+	if (rateCount > limit) {
+		throw TooMuchEarnOrdered(`wallet: ${ wallet }, type: ${ type } exceeded the limit: ${ limit } with: ${ rateCount }`);
 	}
 }

--- a/tests/src/utils.spec.ts
+++ b/tests/src/utils.spec.ts
@@ -4,15 +4,14 @@ import * as moment from "moment";
 import * as utils from "../../scripts/bin/utils/utils";
 import { Application } from "../../scripts/bin/models/applications";
 
-import { TooMuchEarnOrdered } from "../../scripts/bin/errors";
 import { path as _path } from "../../scripts/bin/utils/path";
 import * as metrics from "../../scripts/bin/metrics";
-import { throwOnAppEarnLimit } from "../../scripts/bin/utils/rate_limit";
 import * as helpers from "./helpers";
 import { LimitConfig } from "../../scripts/bin/config";
 import { initLogger } from "../../scripts/bin/logging";
 import { MarketplaceError } from "../../scripts/bin/errors";
 import { close as closeModels, init as initModels } from "../../scripts/bin/models/index";
+import { rateLimitAppEarn } from "../../scripts/bin/utils/rate_limit";
 
 describe("util functions", () => {
 	test("path should return absolute path in the project", () => {
@@ -56,11 +55,11 @@ describe("util functions", () => {
 			};
 			const app: Application = await helpers.createApp(utils.generateId(), limits);
 			for (let i = 0; i < 3; i++) {
-				await throwOnAppEarnLimit(app.id, "total_earn", app.config.limits.minute_total_earn, moment.duration({ minutes: 1 }), 100);
+				await rateLimitAppEarn(app.id, app.config.limits.minute_total_earn, moment.duration({ minutes: 1 }), 100);
 			}
 
 			try {
-				await throwOnAppEarnLimit(app.id, "total_earn", app.config.limits.minute_total_earn, moment.duration({ minutes: 1 }), 100);
+				await rateLimitAppEarn(app.id, app.config.limits.minute_total_earn, moment.duration({ minutes: 1 }), 100);
 				expect(true).toBeFalsy(); // should throw and not get here
 			} catch (e) {
 				if (e instanceof MarketplaceError) {


### PR DESCRIPTION
This way when there are 2 rate limits with different durations but the same prefix they don't collide
Also add rate limit on wallet earn, so a user can't earn too much into a single wallet