### PR TITLE
Eco 901 get order return only user orders

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+- [ ] linked to a JIRA issue
+- [ ] description of the change
+- [ ] tests for the newly added code
+- [ ] if this is a breaking change, contains backward support code
+- [ ] if this requires client changes or partner updates, updated dependendants
+- [ ] were metrics and alerts added
+- [ ] should I change documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ services: docker
 node_js:
   - "10"
 
-before_install:
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-
 before_script:
   - make build db # db - for make test
   - make generate-funding-address

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ services: docker
 node_js:
   - "10"
 
+before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+
 before_script:
   - make build db # db - for make test
   - make generate-funding-address

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV BUILD_COMMIT $BUILD_COMMIT
 ENV BUILD_TIMESTAMP $BUILD_TIMESTAMP
 
 EXPOSE 3000
-HEALTHCHECK --start_period=10s --interval=1m --timeout=5s --retries=3 CMD wget localhost:3000/status -q -O - > /dev/null 2>&1
+HEALTHCHECK --interval=1m --timeout=5s --retries=3 CMD wget localhost:3000/status -q -O - > /dev/null 2>&1
 
 # run the api server
 CMD [ "npm", "run", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ ENV BUILD_COMMIT $BUILD_COMMIT
 ENV BUILD_TIMESTAMP $BUILD_TIMESTAMP
 
 EXPOSE 3000
+HEALTHCHECK --start_period=10s --interval=1m --timeout=5s --retries=3 CMD wget localhost:3000/status -q -O - > /dev/null 2>&1
 
 # run the api server
 CMD [ "npm", "run", "start" ]

--- a/scripts/src/admin/services.ts
+++ b/scripts/src/admin/services.ts
@@ -510,7 +510,7 @@ export async function getOrders(params: any, query: Paging & { status?: OpenOrde
 }
 
 export async function retryOrder(params: { order_id: string }, query: any): Promise<string> {
-	const order = await Order.getOne(params.order_id);
+	const order = await Order.getOne({ orderId: params.order_id });
 
 	if (!order) {
 		throw new Error("order not found: " + params.order_id);

--- a/scripts/src/internal/services.ts
+++ b/scripts/src/internal/services.ts
@@ -91,7 +91,7 @@ async function getPaymentJWT(order: db.Order, appId: string, userId: string): Pr
 }
 
 export async function paymentComplete(payment: CompletedPayment) {
-	const order = await db.Order.getOne(payment.id);
+	const order = await db.Order.getOne({ orderId: payment.id });
 	if (!order) {
 		logger().error(`received payment for unknown order id ${ payment.id }`);
 		return;
@@ -181,7 +181,7 @@ export async function paymentComplete(payment: CompletedPayment) {
 }
 
 export async function paymentFailed(payment: FailedPayment) {
-	const order = await db.Order.getOne(payment.id);
+	const order = await db.Order.getOne({ orderId: payment.id });
 	if (!order) {
 		logger().error(`received payment for unknown order id ${ payment.id }`);
 		return;

--- a/scripts/src/models/orders.ts
+++ b/scripts/src/models/orders.ts
@@ -219,9 +219,10 @@ export const Order = {
 
 		updateQueryWithFilter(query, "id", filters.orderId, "ordr");
 		updateQueryWithFilter(query, "status", filters.status, "ordr");
-		updateQueryWithFilter(query, "user_id", filters.userId, "context");
+		updateQueryWithFilter(query, "nonce", filters.nonce, "ordr");
 		updateQueryWithFilter(query, "origin", filters.origin, "ordr");
 		updateQueryWithFilter(query, "offer_id", filters.offerId, "ordr");
+		updateQueryWithFilter(query, "user_id", filters.userId, "context");
 
 		return query;
 	},
@@ -355,11 +356,10 @@ class OrderImpl extends CreationDateModel implements Order {
 	public async save(): Promise<this> {
 		await getManager().transaction(async mgr => {
 			for (const context of this.contexts) {
-				(context as any).order = this;
-				(context as any).orderId = this.id;
-				(context as any).user_id = context.user.id;
+				(context as Mutable<OrderContext>).order = this;
+				(context as Mutable<OrderContext>).orderId = this.id;
+				(context as Mutable<OrderContext>).userId = context.user.id;
 			}
-
 			await mgr.save(this);
 		});
 

--- a/scripts/src/public/routes/orders.ts
+++ b/scripts/src/public/routes/orders.ts
@@ -98,7 +98,7 @@ export const submitOrder = async function(req: SubmitOrderRequest, res: Response
  * cancel an order
  */
 export const cancelOrder = async function(req: GetOrderRequest, res: Response) {
-	await cancelOrderService(req.params.order_id);
+	await cancelOrderService(req.params.order_id, req.context.user!.id);
 	res.status(204).send();
 } as any as RequestHandler;
 

--- a/scripts/src/public/services/orders.ts
+++ b/scripts/src/public/services/orders.ts
@@ -70,9 +70,10 @@ export interface Order extends BaseOrder {
 }
 
 export async function getOrder(orderId: string, userId: string): Promise<Order> {
-	const order = await db.Order.getOne({ userId, orderId, status: "!opened" }) as db.MarketplaceOrder | db.ExternalOrder;
 
-	if (!order) {
+	const order = await db.Order.getOne({ orderId, status: "!opened" });
+
+	if (!order || order.contextFor(userId) === null) {
 		throw NoSuchOrder(orderId);
 	}
 
@@ -88,9 +89,9 @@ export async function getOrder(orderId: string, userId: string): Promise<Order> 
 }
 
 export async function changeOrder(orderId: string, userId: string, change: Partial<Order>): Promise<Order> {
-	const order = await db.Order.getOne({ userId, orderId, status: "!opened" }) as db.MarketplaceOrder | db.ExternalOrder;
+	const order = await db.Order.getOne({ orderId, status: "!opened" });
 
-	if (!order) {
+	if (!order || order.contextFor(userId) === null) {
 		throw NoSuchOrder(orderId);
 	}
 	if (order.status === "completed") {
@@ -291,9 +292,9 @@ export async function submitOrder(
 	acceptsLanguagesFunc?: ExpressRequest["acceptsLanguages"]): Promise<Order> {
 
 	logger().info("submitOrder", { orderId });
-	const order = await db.Order.getOne({ userId, orderId }) as db.MarketplaceOrder | db.ExternalOrder;
+	const order = await db.Order.getOne({ orderId });
 
-	if (!order) {
+	if (!order || order.contextFor(userId) === null) {
 		throw NoSuchOrder(orderId);
 	}
 	if (order.status !== "opened") {
@@ -349,8 +350,8 @@ export async function submitOrder(
 
 export async function cancelOrder(orderId: string, userId: string): Promise<void> {
 	// you can only delete an open order - not a pending order
-	const order = await db.Order.getOne({ userId, orderId, status: "opened" });
-	if (!order) {
+	const order = await db.Order.getOne({ orderId, status: "opened" });
+	if (!order || order.contextFor(userId) === null) {
 		throw NoSuchOrder(orderId);
 	}
 
@@ -366,10 +367,7 @@ export async function getOrderHistory(
 
 	// XXX use the cursor input values
 	const status: db.OrderStatusAndNegation = "!opened";
-	const orders = await db.Order.getAll(
-		{ ...filters, userId, status },
-		limit
-	) as Array<db.MarketplaceOrder | db.ExternalOrder>;
+	const orders = await db.Order.getAll({ ...filters, userId, status }, limit);
 
 	return {
 		orders: orders.map(order => {

--- a/scripts/src/public/services/orders.ts
+++ b/scripts/src/public/services/orders.ts
@@ -70,7 +70,7 @@ export interface Order extends BaseOrder {
 }
 
 export async function getOrder(orderId: string, userId: string): Promise<Order> {
-	const order = await db.Order.getOne(orderId, "!opened") as db.MarketplaceOrder | db.ExternalOrder;
+	const order = await db.Order.getOne({ orderId, status: "!opened" }) as db.MarketplaceOrder | db.ExternalOrder;
 
 	if (!order) {
 		throw NoSuchOrder(orderId);
@@ -88,7 +88,7 @@ export async function getOrder(orderId: string, userId: string): Promise<Order> 
 }
 
 export async function changeOrder(orderId: string, userId: string, change: Partial<Order>): Promise<Order> {
-	const order = await db.Order.getOne(orderId, "!opened") as db.MarketplaceOrder | db.ExternalOrder;
+	const order = await db.Order.getOne({ orderId, status: "!opened" }) as db.MarketplaceOrder | db.ExternalOrder;
 
 	if (!order) {
 		throw NoSuchOrder(orderId);
@@ -254,7 +254,8 @@ export async function createExternalOrder(jwt: string, user: User): Promise<Open
 	const payload = await validateExternalOrderJWT(jwt, user.appUserId);
 	const nonce = payload.nonce || db.Order.DEFAULT_NONCE;
 
-	let order = await db.Order.findBy({ offerId: payload.offer.id, userId: user.id, nonce });
+	const orders = await db.Order.getAll({ offerId: payload.offer.id, userId: user.id, nonce });
+	let order = orders.length > 0 ? orders[0] : undefined;
 
 	if (!order || order.status === "failed") {
 		if (isPayToUser(payload)) {
@@ -290,7 +291,7 @@ export async function submitOrder(
 	acceptsLanguagesFunc?: ExpressRequest["acceptsLanguages"]): Promise<Order> {
 
 	logger().info("submitOrder", { orderId });
-	const order = await db.Order.getOne(orderId) as db.MarketplaceOrder | db.ExternalOrder;
+	const order = await db.Order.getOne({ orderId }) as db.MarketplaceOrder | db.ExternalOrder;
 
 	if (!order) {
 		throw NoSuchOrder(orderId);
@@ -348,7 +349,7 @@ export async function submitOrder(
 
 export async function cancelOrder(orderId: string): Promise<void> {
 	// you can only delete an open order - not a pending order
-	const order = await db.Order.getOne(orderId, "opened");
+	const order = await db.Order.getOne({ orderId, status: "opened" });
 	if (!order) {
 		throw NoSuchOrder(orderId);
 	}
@@ -366,7 +367,7 @@ export async function getOrderHistory(
 	// XXX use the cursor input values
 	const status: db.OrderStatusAndNegation = "!opened";
 	const orders = await db.Order.getAll(
-		Object.assign({}, filters, { userId, status }),
+		{ ...filters, userId, status },
 		limit
 	) as Array<db.MarketplaceOrder | db.ExternalOrder>;
 

--- a/scripts/src/public/services/orders.ts
+++ b/scripts/src/public/services/orders.ts
@@ -70,7 +70,7 @@ export interface Order extends BaseOrder {
 }
 
 export async function getOrder(orderId: string, userId: string): Promise<Order> {
-	const order = await db.Order.getOne({ orderId, status: "!opened" }) as db.MarketplaceOrder | db.ExternalOrder;
+	const order = await db.Order.getOne({ userId, orderId, status: "!opened" }) as db.MarketplaceOrder | db.ExternalOrder;
 
 	if (!order) {
 		throw NoSuchOrder(orderId);
@@ -88,7 +88,7 @@ export async function getOrder(orderId: string, userId: string): Promise<Order> 
 }
 
 export async function changeOrder(orderId: string, userId: string, change: Partial<Order>): Promise<Order> {
-	const order = await db.Order.getOne({ orderId, status: "!opened" }) as db.MarketplaceOrder | db.ExternalOrder;
+	const order = await db.Order.getOne({ userId, orderId, status: "!opened" }) as db.MarketplaceOrder | db.ExternalOrder;
 
 	if (!order) {
 		throw NoSuchOrder(orderId);
@@ -291,7 +291,7 @@ export async function submitOrder(
 	acceptsLanguagesFunc?: ExpressRequest["acceptsLanguages"]): Promise<Order> {
 
 	logger().info("submitOrder", { orderId });
-	const order = await db.Order.getOne({ orderId }) as db.MarketplaceOrder | db.ExternalOrder;
+	const order = await db.Order.getOne({ userId, orderId }) as db.MarketplaceOrder | db.ExternalOrder;
 
 	if (!order) {
 		throw NoSuchOrder(orderId);
@@ -347,9 +347,9 @@ export async function submitOrder(
 	return orderDbToApi(order, userId);
 }
 
-export async function cancelOrder(orderId: string): Promise<void> {
+export async function cancelOrder(orderId: string, userId: string): Promise<void> {
 	// you can only delete an open order - not a pending order
-	const order = await db.Order.getOne({ orderId, status: "opened" });
+	const order = await db.Order.getOne({ userId, orderId, status: "opened" });
 	if (!order) {
 		throw NoSuchOrder(orderId);
 	}

--- a/scripts/src/tests/helpers.ts
+++ b/scripts/src/tests/helpers.ts
@@ -144,7 +144,7 @@ export async function createOffers() {
 }
 
 export async function completePayment(orderId: string) {
-	const order = (await Order.getOne(orderId))!;
+	const order = (await Order.getOne({ orderId }))!;
 	const user = order.contexts[0].user;
 	const payment: CompletedPayment = {
 		id: order.id,

--- a/scripts/src/tests/services/orders.spec.ts
+++ b/scripts/src/tests/services/orders.spec.ts
@@ -219,7 +219,7 @@ describe("test orders", async () => {
 			await order.save();
 			await helpers.completePayment(order.id);
 
-			const completedOrder = (await Order.getOne(order.id))!;
+			const completedOrder = (await Order.getOne({ orderId: order.id }))!;
 			expect(completedOrder.value!.type).toBe("payment_confirmation");
 			return jsonwebtoken.decode(
 				(completedOrder.value as JWTValue).jwt, { complete: true }
@@ -283,10 +283,10 @@ describe("test orders", async () => {
 		{
 			const openOrder = await createMarketplaceOrder(offers.offers[0].id, user);
 			await submitOrder(openOrder.id, user.id, "{}", user.walletAddress, user.appId);
-			const dbOrder = (await Order.getOne(openOrder.id))!;
+			const dbOrder = (await Order.getOne({ orderId: openOrder.id }))!;
 			const expDate = dbOrder.expirationDate!;
 			await setFailedOrder(dbOrder, TransactionTimeout());
-			const dbOrder2 = (await Order.getOne(openOrder.id))!;
+			const dbOrder2 = (await Order.getOne({ orderId: openOrder.id }))!;
 			expect(expDate.getTime()).toBeGreaterThan(dbOrder2.currentStatusDate.getTime());
 		}
 
@@ -294,10 +294,10 @@ describe("test orders", async () => {
 		{
 			const openOrder = await createMarketplaceOrder(offers.offers[0].id, user);
 			await submitOrder(openOrder.id, user.id, "{}", user.walletAddress, user.appId);
-			const dbOrder = (await Order.getOne(openOrder.id))!;
+			const dbOrder = (await Order.getOne({ orderId: openOrder.id }))!;
 			const expDate = dbOrder.expirationDate!;
 			await setFailedOrder(dbOrder, TransactionTimeout(), expDate);
-			const dbOrder2 = (await Order.getOne(openOrder.id))!;
+			const dbOrder2 = (await Order.getOne({ orderId: openOrder.id }))!;
 			expect(expDate.getTime()).toEqual(dbOrder2.currentStatusDate.getTime());
 		}
 	});

--- a/scripts/src/tests/services/orders.spec.ts
+++ b/scripts/src/tests/services/orders.spec.ts
@@ -392,5 +392,4 @@ describe("test orders", async () => {
 		// user2 should be able to open an order
 		await expect(createMarketplaceOrder(offer.id, user2)).resolves.toBeDefined();
 	});
-})
-;
+});


### PR DESCRIPTION
Currently when requesting another user's orders the server crashes with error 500.
This PR converts it to 404.

* I reduced code duplication in the getOne/ getAll/ findBy functions by using a common query builder
* added a test for the new 404 error
* I added a docker healthcheck