### PR TITLE
fix_wrong_jwt_5xx_error

### DIFF
--- a/scripts/src/errors.ts
+++ b/scripts/src/errors.ts
@@ -47,7 +47,8 @@ const CODES = {
 		InvalidWalletAddress: 8,
 		ExpiredJwt: 9,
 		InvalidJwtIssuedTime: 10,
-		MissingFieldJWT: 11
+		MissingFieldJWT: 11,
+		BadJWTInput: 12
 	},
 	TransactionFailed: {
 		WrongSender: 1,
@@ -208,6 +209,10 @@ export function InvalidJwtIssuedTime(iat: number) {
 
 export function MissingFieldJWT(fieldName: string) {
 	return BadRequestError(CODES.BadRequest.MissingFieldJWT, `The JWT ${ fieldName } field is missing`);
+}
+
+export function BadJWTInput(token: string) {
+	return BadRequestError(CODES.BadRequest.BadJWTInput, `JWT ${token} failed to decode`);
 }
 
 export function InvalidPollAnswers() {


### PR DESCRIPTION
fixes:
```json
{"error": "Error\n\tmethod: POST\n\tpath: /v1/users\n\tpayload: 
{\"wallet_address\":\"GDB263XXBKKEDLF46QSSHNWW24F34VSP37LZ27RB44HGPD4M6F7I7KSD\",\"jwt\":\"
{\\\"jwt\\\":\\\"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImVzMjU2XzAifQ.eyJpc3MiOiJ0ZXN0Iiwi
ZXhwIjoxNTQ3MjExMjM2LCJpYXQiOjE1NDcxODk2MzYsInN1YiI6InJlZ2lzdGVyIiwidXNlcl9pZCI6IjE2MjQw
NzkwIn0.f_n1rPVdjhRk0ylGCGpc0QesKNiZMclO2DUGpHA1vGN8fvAeRQ5T8BqnVociJ54kc8MkBo_G78x
5nWOHbxQ9DQ\\\"}\",\"sign_in_type\":\"jwt\",\"device_id\":\"489730f2-2d2b-44f6-8a8f-
384c4716d09b\"}\n\tmessage: Cannot read property 'header' of null\n\tstack: TypeError: Cannot read
 property 'header' of null\n    at Object.<anonymous> (/opt/app/scripts/src/public/jwt.ts:34:14)\n    at 
Generator.next (<anonymous>)\n    at /opt/app/scripts/bin/public/jwt.js:7:71\n    at new Promise 
(<anonymous>)\n    at __awaiter (/opt/app/scripts/bin/public/jwt.js:3:12)\n    at Object.verify 
(/opt/app/scripts/bin/public/jwt.js:18:12)\n    at Object.<anonymous> 
(/opt/app/scripts/src/public/services/applications.ts:17:24)\n    at Generator.next (<anonymous>)\n    at
 /opt/app/scripts/bin/public/services/applications.js:7:71\n    at new Promise (<anonymous>)\n    at 
__awaiter (/opt/app/scripts/bin/public/services/applications.js:3:12)\n    at Object.validateRegisterJWT 
(/opt/app/scripts/bin/public/services/applications.js:16:12)\n    at 
/opt/app/scripts/src/public/routes/users.ts:48:19\n    at Generator.next (<anonymous>)\n    at 
/opt/app/scripts/bin/public/routes/users.js:7:71\n    at new Promise (<anonymous>)",
```