### PR TITLE
make sure that when paying to self you don't get an earn order

### DIFF
--- a/scripts/src/models/orders.ts
+++ b/scripts/src/models/orders.ts
@@ -558,15 +558,15 @@ export class OrderContext extends BaseEntity {
 	@JoinColumn({ name: "user_id" })
 	public readonly user!: User;
 
-	@Column()
-	public type!: OfferType;
-
 	@Index()
 	@Column()
 	public wallet!: string;
 
 	@Column("simple-json")
 	public readonly meta!: OrderMeta;
+
+	@PrimaryColumn()
+	public type!: OfferType;
 
 	@PrimaryColumn({ name: "order_id" })
 	public readonly orderId!: string;


### PR DESCRIPTION
we had a bug where p2p to self would result in an external earn order and the user (self) would actually get the kin and the balance would go up.
this makes sure that it won't happen, plus an added test to check it.
