### PR TITLE
ECO-1253 don't return 500 on 404 from migration service and ECO-1263 …

### DIFF
--- a/scripts/src/public/services/users.ts
+++ b/scripts/src/public/services/users.ts
@@ -90,6 +90,21 @@ export type UpdateUserProps = {
 	walletAddress: string;
 };
 
+export async function isRestoreAllowed(walletAddress: string, appId: string, addOnNonExisting: boolean = true): Promise<boolean> {
+	const appWallet = await WalletApplication.findOne({ walletAddress });
+	if (appWallet) {
+		logger().info(`Wallet ${ walletAddress } is associated with app ${ appWallet.appId }, current app is ${ appId }`);
+		if (appWallet.appId !== appId) {
+			return false;
+		}
+	} else if (addOnNonExisting) {
+		logger().info(`Wallet ${ walletAddress } does not exist in wallet_application table, add`);
+		const newWallet = WalletApplication.create({ walletAddress, appId });
+		await newWallet.save();
+	}
+	return true;
+}
+
 export async function updateUser(user: User, props: UpdateUserProps) {
 	if (props.walletAddress) {
 		const wallets = await user.getWallets();
@@ -99,17 +114,9 @@ export async function updateUser(user: User, props: UpdateUserProps) {
 		const walletAddress = props.walletAddress;
 
 		/*  Start of Cross-app restore check (when removing, remove test too) */
-		const appWallet = await WalletApplication.findOne({ walletAddress });
-		if (!appWallet) {
-			logger().info(`Wallet ${ walletAddress } does not exist in wallet_application table, adding`);
-			const newWallet = WalletApplication.create({ walletAddress, appId });
-			await newWallet.save();
-		} else {
-			logger().info(`Wallet ${ walletAddress } is associated with app ${ appWallet.appId }, current app is ${ appId }`);
-			if (appWallet.appId !== appId) {
-				createRestoreRequestFailed(user.id, props.deviceId, "blocking cross-app restore request").report();
-				throw CrossAppWallet(walletAddress, appId);
-			}
+		if (!isRestoreAllowed(walletAddress, appId)) {
+			createRestoreRequestFailed(user.id, props.deviceId, "blocking cross-app restore request").report();
+			throw CrossAppWallet(walletAddress, appId);
 		}
 		/*  End of Cross-app restore check */
 


### PR DESCRIPTION
```v2/migration/info```:
* Don't throw 500 for a 404. Instead return ```should_migrate: false```
* Return is wallet allowed to be restored (wallet+appid)

- [x] linked to a JIRA issue
- [x] description of the change
- [ ] tests for the newly added code
- [ ] if this is a breaking change, contains backward support code
- [ ] if this requires client changes or partner updates, updated dependendants
- [ ] were metrics and alerts added
- [ ] should I change documentation
