### PR TITLE
only create wallet when not created

### DIFF
--- a/scripts/src/internal/services.ts
+++ b/scripts/src/internal/services.ts
@@ -3,7 +3,7 @@ import * as metrics from "../metrics";
 import * as db from "../models/orders";
 import { User, Wallet } from "../models/users";
 import { pick, removeDuplicates } from "../utils/utils";
-import { Asset, Offer, OrderValue } from "../models/offers";
+import { Asset, OrderValue } from "../models/offers";
 import { setWatcherEndpoint, Watcher } from "../public/services/payment";
 import { create as createSpendOrderPaymentConfirmed } from "../analytics/events/spend_order_payment_confirmed";
 import { create as createStellarAccountCreationFailed } from "../analytics/events/stellar_account_creation_failed";
@@ -18,7 +18,8 @@ import { Application, AppOffer } from "../models/applications";
 
 const BLOCKCHAIN = "kin-prod";
 const RS512_APPS = ["test", "smpl"];
-const ACCOUNT_EXISTS_REASON = "account exists";
+// the reason given when payment-service tries to create an already existing account
+const ACCOUNT_EXISTS_BLOCKCHAIN_ERROR = "account exists";
 
 export type WalletCreationSuccessData = {
 	id: string; // user id
@@ -39,7 +40,7 @@ export type WalletCreationFailureData = {
 
 export async function walletCreationFailure(data: WalletCreationFailureData) {
 	createStellarAccountCreationFailed(data.id, data.reason).report();
-	if (data.reason === ACCOUNT_EXISTS_REASON) {
+	if (data.reason === ACCOUNT_EXISTS_BLOCKCHAIN_ERROR) {
 		logger().warn("wallet already created", data);
 		await Wallet.setAccountCreated(data.wallet_address);
 	} else {

--- a/scripts/src/models/users.ts
+++ b/scripts/src/models/users.ts
@@ -206,6 +206,15 @@ export class Wallets {
 @Entity({ name: "user_wallets" })
 @Register
 export class Wallet extends BaseEntity {
+	public static async setAccountCreated(walletAddress: string) {
+		await Wallet.update({
+			where: {
+				address: walletAddress,
+				accountCreatedDate: null
+			}
+		}, { accountCreatedDate: new Date() });
+	}
+
 	@ManyToOne(type => User)
 	@JoinColumn({ name: "user_id" })
 	public readonly user!: User;
@@ -221,6 +230,9 @@ export class Wallet extends BaseEntity {
 
 	@Column({ name: "created_date" })
 	public createdDate!: Date;
+
+	@Column({ name: "account_created_date", nullable: true })
+	public accountCreatedDate!: Date;
 
 	@Column({ name: "last_used_date" })
 	public lastUsedDate!: Date;

--- a/scripts/src/public/services/users.ts
+++ b/scripts/src/public/services/users.ts
@@ -126,13 +126,14 @@ export async function updateUser(user: User, props: UpdateUserProps) {
 			throw NoSuchApp(appId);
 		}
 
-		if (!app.allowsNewWallet(totalWalletCount)) {
+		if (!wallets.has(walletAddress) && !app.allowsNewWallet(totalWalletCount)) {
 			metrics.maxWalletsExceeded(appId);
 			throw MaxWalletsExceeded();
 		}
 
+		const createdOnBlockchain = wallets.has(walletAddress) && wallets.get(walletAddress)!.accountCreatedDate !== null;
 		const isNewWallet = await user.updateWallet(props.deviceId, walletAddress);
-		if (isNewWallet) {
+		if (isNewWallet || !createdOnBlockchain ) {
 			logger().info(`creating stellar wallet for user ${ appId }: ${ props.walletAddress }`);
 			await payment.createWallet(walletAddress, appId, user.id);
 		}

--- a/scripts/src/public/services/users.ts
+++ b/scripts/src/public/services/users.ts
@@ -2,7 +2,7 @@ import { Brackets } from "typeorm";
 
 import * as metrics from "../../metrics";
 import { Order } from "../../models/orders";
-import { dateParser, isNothing, normalizeError, readUTCDate } from "../../utils/utils";
+import { isNothing, normalizeError, readUTCDate } from "../../utils/utils";
 import { Application } from "../../models/applications";
 import { getDefaultLogger as logger } from "../../logging";
 import { User, AuthToken as DbAuthToken, WalletApplication } from "../../models/users";


### PR DESCRIPTION
Requires:
```
ALTER TABLE user_wallets ADD COLUMN account_created_date TIMESTAMP NULL;
```

Depends on https://github.com/kinecosystem/payment-service/pull/42

## Description
Only create wallet on blockchain if it hasn't been created yet. When the wallet is created, we mark this in the DB so it won't be created next time.