### PR TITLE
bugfix: typeorm created query without where clause

### DIFF
--- a/scripts/src/models/users.ts
+++ b/scripts/src/models/users.ts
@@ -208,11 +208,10 @@ export class Wallets {
 export class Wallet extends BaseEntity {
 	public static async setAccountCreated(walletAddress: string) {
 		await Wallet.update({
-			where: {
+				accountCreatedDate: null,
 				address: walletAddress,
-				accountCreatedDate: null
-			}
-		}, { accountCreatedDate: new Date() });
+			} as any, // typescript doesn't like the first argument when there are 2 fields to search on
+			{ accountCreatedDate: new Date() });
 	}
 
 	@ManyToOne(type => User)


### PR DESCRIPTION
TypeOrm ignores the where clause when given in the `where: {}` form for the update function.
When using it as a "repository", the types don't work well and we have to use `as any` to pass the query to the update function.