### PR TITLE
use precise query to get a single order

### DIFF
--- a/scripts/src/models/orders.ts
+++ b/scripts/src/models/orders.ts
@@ -241,9 +241,8 @@ export const Order = {
 	 */
 	async getAll<T extends Order>(filters: GetOrderFilters & ({ userId: string } | { walletAddress: string }), limit: number = 25): Promise<T[]> {
 		const orderIdQuery = await (this.genericGet(filters)
-			.limit(limit + 1)
-			.getMany()); // +1 to account for p2p
-		console.log("GOT", orderIdQuery);
+			.limit(limit)
+			.getMany());
 		const ids = orderIdQuery.map(res => res.id);
 		if (!ids.length) {
 			return []; // empty array causes sql syntax error

--- a/scripts/src/public/services/orders.ts
+++ b/scripts/src/public/services/orders.ts
@@ -289,8 +289,7 @@ export async function createExternalOrder(jwt: string, user: User, userDeviceId:
 	const payload = await validateExternalOrderJWT(jwt, user, userDeviceId);
 	const nonce = payload.nonce || db.Order.DEFAULT_NONCE;
 
-	const orders = await db.Order.getAll({ offerId: payload.offer.id, userId: user.id, nonce });
-	let order = orders.length > 0 ? orders[0] : undefined;
+	let order = await db.Order.getOne({ offerId: payload.offer.id, userId: user.id, nonce });
 
 	if (!order || order.status === "failed") {
 		if (isPayToUser(payload)) {

--- a/scripts/src/tests/services/orders.spec.ts
+++ b/scripts/src/tests/services/orders.spec.ts
@@ -241,6 +241,18 @@ describe("test v2 orders", async () => {
 		expect(found.status).toEqual("failed");
 	});
 
+	test("getOne by offerId", async () => {
+		const user = await helpers.createUser();
+		const order = await helpers.createP2POrder(user.id);
+
+		const found = (await Order.getOne({ userId: user.id, offerId: order.offerId, nonce: order.nonce }))!;
+		expect(found.id).toEqual(order.id);
+
+		const notFound = (await Order.getOne({ userId: "other user", offerId: order.offerId, nonce: order.nonce }))!;
+		expect(notFound).toBeUndefined();
+
+	});
+
 	test("getOrder returns only my orders", async () => {
 		const user1 = await helpers.createUser();
 		const user2 = await helpers.createUser();

--- a/scripts/src/tests/services/orders.spec.ts
+++ b/scripts/src/tests/services/orders.spec.ts
@@ -224,6 +224,17 @@ describe("test v2 orders", async () => {
 		console.log(res.body);
 	});
 
+	test("create and find multiple p2p orders", async () => {
+		const user = await helpers.createUser();
+		const token = (await AuthToken.findOne({ userId: user.id }))!;
+		const limit = 5;
+		for (let i = 0; i < limit; i++) {
+			await helpers.createP2POrder(user.id);
+		}
+		const orders = await Order.getAll({ userId: user.id }, limit);
+		expect(orders.length).toEqual(limit);
+	});
+
 	test("setFailedOrder marks p2p order as expired", async () => {
 		const user = await helpers.createUser();
 		const walletAddress = (await user.getWallets()).lastUsed()!.address;


### PR DESCRIPTION
`getOne` will also find by offerId+nonce+userId
`getAll` will filter out the original orderId list with the given filter (instead of ignoring the filter).