### PR TITLE
get last used wallet if no deviceId is given

### DIFF
--- a/scripts/src/models/users.ts
+++ b/scripts/src/models/users.ts
@@ -45,14 +45,19 @@ export class User extends CreationDateModel {
 
 		if (deviceId) {
 			conditions.deviceId = deviceId;
+			const wallets = await Wallet.find(conditions);
+			if (wallets.length) {
+				return new Wallets(wallets);
+			} // else delete deviceId and let find generic wallets
+			delete conditions.deviceId;
 		}
 
-		const wallets = await Wallet.find(conditions);
+		let wallets = await Wallet.find(conditions);
 		if (wallets.length === 0 && this.walletAddress) {
-			await this.lazyMigrateWallet(deviceId); // TODO can we get rid of this?
+			await this.lazyMigrateWallet(deviceId);
+			wallets = await Wallet.find(conditions);
 		}
-
-		return new Wallets(await Wallet.find(conditions));
+		return new Wallets(wallets);
 	}
 
 	public async updateWallet(deviceId: string, walletAddress: string): Promise<boolean> {

--- a/scripts/src/public/auth.ts
+++ b/scripts/src/public/auth.ts
@@ -121,8 +121,7 @@ async function checkMigrationNeeded(req: AuthenticatedRequest): Promise<boolean>
 		return true;
 	}
 	if (app.shouldApplyGradualMigration() && !await checkedMigrationRecently(user.id)) {
-		const wallet = (await user.getWallets(deviceId)).lastUsed() ||
-			(await user.getWallets()).lastUsed();
+		const wallet = (await user.getWallets(deviceId)).lastUsed();
 		if (!wallet) {
 			// :( TODO shouldn't happen - log this
 			logger().error(`no wallet found for ${ user.id }`);

--- a/scripts/src/public/services/users.ts
+++ b/scripts/src/public/services/users.ts
@@ -308,7 +308,7 @@ async function createUserProfileObject(user: User, deviceId: string): Promise<Us
 		}
 	}
 
-	const wallet = (await user.getWallets(deviceId)).lastUsed();
+	const wallet = (await user.getWallets(deviceId)).lastUsed() || (await user.getWallets()).lastUsed();
 
 	return {
 		stats,

--- a/scripts/src/public/services/users.ts
+++ b/scripts/src/public/services/users.ts
@@ -308,7 +308,7 @@ async function createUserProfileObject(user: User, deviceId: string): Promise<Us
 		}
 	}
 
-	const wallet = (await user.getWallets(deviceId)).lastUsed() || (await user.getWallets()).lastUsed();
+	const wallet = (await user.getWallets(deviceId)).lastUsed();
 
 	return {
 		stats,


### PR DESCRIPTION
@Elaz @liorama 

The iOS client relies on us giving the correct wallet address. When the deviceId changes on the client this caused the server to return `null` as the wallet. This will return the lastUsed wallet across all devices.